### PR TITLE
Add GitHub action; #1 Update to static appimage runtime and use zstd 

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -3,6 +3,8 @@ name: Docker Image CI
 on:
   schedule:
     - cron: '0 0 * * 0'   # At 00:00 on Sunday
+  push:
+    branches: [ "github_action" ]
 
 jobs:
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -3,8 +3,6 @@ name: Docker Image CI
 on:
   schedule:
     - cron: '0 0 * * 0'   # At 00:00 on Sunday
-  push:
-    branches: [ "github_action" ]
 
 jobs:
 
@@ -41,6 +39,4 @@ jobs:
         docker build --build-arg SIGNAL_BRANCH=$LATEST_VERSION --output out .
         echo "Upoading GitHub Release..."
         gh release create $LATEST_VERSION ./out/*.AppImage
-        echo "Generating md5 sum of built AppImage..."
-        echo $(md5dsum ./out/*.AppImage)
         echo "Version uploaded."

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,11 +1,8 @@
 name: Docker Image CI
 
 on:
-  push:
-    branches: [ "github_action" ]   # testing
-    #branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  schedule:
+    - cron: '0 0 * * 0'   # At 00:00 on Sunday
 
 jobs:
 
@@ -18,6 +15,7 @@ jobs:
     - name: Compare official Signal-Desktop version to AppImage version
       run: |
         set -e
+        echo "Curling versions..."
         LATEST_VERSION_OFFICIAL=$(curl -Ls https://api.github.com/repos/signalapp/Signal-Desktop/releases/latest | jq -r '.tag_name')
         LATEST_VERSION_APPIMAGE=$(curl -Ls https://api.github.com/repos/karo-solutions/Signal-Desktop-AppImage/releases/latest | jq -r '.tag_name')
         echo "Latest official version: $LATEST_VERSION_OFFICIAL"
@@ -37,7 +35,10 @@ jobs:
         GH_TOKEN: ${{ github.token }}       # set automatically - no personal access token needed - But adjusted workflow permissions: https://github.com/karo-solutions/Signal-Desktop-AppImage/settings/actions
       run: |
         set -e
-        # docker build --build-arg SIGNAL_BRANCH=$LATEST_VERSION --output out .
-        # gh release create $LATEST_VERSION./out/*.AppImage
-        echo "test" >> release.tar.xz
-        gh release create $LATEST_VERSION release.tar.xz
+        echo "Building Signal..."
+        docker build --build-arg SIGNAL_BRANCH=$LATEST_VERSION --output out .
+        echo "Upoading GitHub Release..."
+        gh release create $LATEST_VERSION./out/*.AppImage
+        echo "Generating md5 sum of built AppImage..."
+        echo $(md5dsum ./out/*.AppImage)
+        echo "Version uploaded."

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -9,19 +9,20 @@ on:
 
 jobs:
 
-  build:
-
+  build-and-release:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Compare official Signal-Desktop version to AppImage version
       run: |
         set -e
         LATEST_VERSION_OFFICIAL=$(curl -Ls https://api.github.com/repos/signalapp/Signal-Desktop/releases/latest | jq -r '.tag_name')
-        LATEST_VERSION_APPIMAGE=$(curl -Ls https://aapi.github.com/repos/karo-solutions/Signal-Desktop-AppImage/releases/latest | jq -r '.tag_name')
-        # Testing...
-        echo "Latest Version: $LATEST_VERSION_APPIMAGE"
+        LATEST_VERSION_APPIMAGE=$(curl -Ls https://api.github.com/repos/karo-solutions/Signal-Desktop-AppImage/releases/latest | jq -r '.tag_name')
+        echo "Latest official version: $LATEST_VERSION_OFFICIAL"
+        echo "Latest AppImage version: $LATEST_VERSION_APPIMAGE"
+
         if [[ "$LATEST_VERSION_OFFICIAL" == "$LATEST_VERSION_APPIMAGE" ]]
         then
           echo "Versions are equal. No need to rebuild Signal-Desktop-Appimage. Exiting..."
@@ -29,18 +30,12 @@ jobs:
         fi
         # store new version in GitHub Environment
         echo "LATEST_VERSION=$LATEST_VERSION_OFFICIAL" >> "$GITHUB_ENV"
-    - name: Build AppImage
+
+    - name: Build and release AppImage
       if: ${{ env.LATEST_VERSION != '' }}   # only run when latest version is set i.e. building a new version is required.
       run: |
         set -e
-        echo $LATEST_VERSION
-        LATEST_VERSION=$(curl -Ls https://aapi.github.com/repos/signalapp/Signal-Desktop/releases/latest | jq -r '.tag_name')
-        echo "Testing error"
-    #- name: Build the Docker image
-    #  run: docker build --build-arg SIGNAL_BRANCH=v7.29.0 --output out .
-    #- name: 'Upload Artifact'
-    #  uses: actions/upload-artifact@v4
-    #  with:
-    #    name: Signal-7.29.0.AppImage
-    #    path: ./out/Signal-7.29.0.AppImage
-    #    retention-days: 5
+        # docker build --build-arg SIGNAL_BRANCH=$LATEST_VERSION --output out .
+        # gh release create $LATEST_VERSION./out/*.AppImage
+        echo "test" >> release.tar.xz
+        gh release create $LATEST_VERSION release.tar.xz

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Build and release AppImage
       if: ${{ env.LATEST_VERSION != '' }}   # only run when latest version is set i.e. building a new version is required.
       env:
-        GH_TOKEN: ${{ github.token }}       # set automatically - no personal access token needed
+        GH_TOKEN: ${{ github.token }}       # set automatically - no personal access token needed - But adjusted workflow permissions: https://github.com/karo-solutions/Signal-Desktop-AppImage/settings/actions
       run: |
         set -e
         # docker build --build-arg SIGNAL_BRANCH=$LATEST_VERSION --output out .

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -40,7 +40,7 @@ jobs:
         echo "Building Signal..."
         docker build --build-arg SIGNAL_BRANCH=$LATEST_VERSION --output out .
         echo "Upoading GitHub Release..."
-        gh release create $LATEST_VERSION./out/*.AppImage
+        gh release create $LATEST_VERSION ./out/*.AppImage
         echo "Generating md5 sum of built AppImage..."
         echo $(md5dsum ./out/*.AppImage)
         echo "Version uploaded."

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -33,6 +33,8 @@ jobs:
 
     - name: Build and release AppImage
       if: ${{ env.LATEST_VERSION != '' }}   # only run when latest version is set i.e. building a new version is required.
+      env:
+        GH_TOKEN: ${{ github.token }}       # set automatically - no personal access token needed
       run: |
         set -e
         # docker build --build-arg SIGNAL_BRANCH=$LATEST_VERSION --output out .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,14 +15,24 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Find latest Signal-Desktop version
+    - name: Compare official Signal-Desktop version to AppImage version
       run: |
-        LATEST_VERSION=$(curl -Ls https://api.github.com/repos/signalapp/Signal-Desktop/releases/latest | jq -r '.tag_name')
-        echo "LATEST_VERSION=$LATEST_VERSION" >> "$GITHUB_ENV"
+        LATEST_VERSION_OFFICIAL=$(curl -Ls https://api.github.com/repos/signalapp/Signal-Desktop/releases/latest | jq -r '.tag_name')
+        LATEST_VERSION_APPIMAGE=$(curl -Ls https://api.github.com/repos/karo-solutions/Signal-Desktop-AppImage/releases/latest | jq -r '.tag_name')
+        # Testing...
+        echo $LATEST_VERSION_APPIMAGE
+        LATEST_VERSION_APPIMAGE=v7.30.0
+        if [[ "$LATEST_VERSION_OFFICIAL" == "$LATEST_VERSION_APPIMAGE" ]]
+        then
+          echo "Versions are equal. No need to rebuild Signal-Desktop-Appimage. Exiting..."
+          exit 0
+        fi
+        # store new version in GitHub Environment
+        echo "LATEST_VERSION=$LATEST_VERSION_OFFICIAL" >> "$GITHUB_ENV"
     - name: Testing
       run: |
         echo $LATEST_VERSION
-        LATEST_VERSION=curl -Ls https://aapi.github.com/repos/signalapp/Signal-Desktop/releases/latest | jq -r '.tag_name'
+        LATEST_VERSION=$(curl -Ls https://aapi.github.com/repos/signalapp/Signal-Desktop/releases/latest) | jq -r '.tag_name'
         echo "Testing error"
     #- name: Build the Docker image
     #  run: docker build --build-arg SIGNAL_BRANCH=v7.29.0 --output out .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
         # store new version in GitHub Environment
         echo "LATEST_VERSION=$LATEST_VERSION_OFFICIAL" >> "$GITHUB_ENV"
     - name: Testing
+      if: ${{ env.LATEST_VERSION != "" }}   #only run when latest version is set i.e. building a new version is required.
       run: |
         echo $LATEST_VERSION
         LATEST_VERSION=$(curl -Ls https://aapi.github.com/repos/signalapp/Signal-Desktop/releases/latest) | jq -r '.tag_name'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         # store new version in GitHub Environment
         echo "LATEST_VERSION=$LATEST_VERSION_OFFICIAL" >> "$GITHUB_ENV"
     - name: Testing
-      if: ${{ env.LATEST_VERSION != "" }}   #only run when latest version is set i.e. building a new version is required.
+      if: ${{ env.LATEST_VERSION != '' }}   #only run when latest version is set i.e. building a new version is required.
       run: |
         echo $LATEST_VERSION
         LATEST_VERSION=$(curl -Ls https://aapi.github.com/repos/signalapp/Signal-Desktop/releases/latest) | jq -r '.tag_name'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         set -e
         LATEST_VERSION_OFFICIAL=$(curl -Ls https://api.github.com/repos/signalapp/Signal-Desktop/releases/latest | jq -r '.tag_name')
-        LATEST_VERSION_APPIMAGE=$(curl -Ls https://api.github.com/repos/karo-solutions/Signal-Desktop-AppImage/releases/latest | jq -r '.tag_name')
+        LATEST_VERSION_APPIMAGE=$(curl -Ls https://aapi.github.com/repos/karo-solutions/Signal-Desktop-AppImage/releases/latest | jq -r '.tag_name')
         # Testing...
         echo "Latest Version: $LATEST_VERSION_APPIMAGE"
         if [[ "$LATEST_VERSION_OFFICIAL" == "$LATEST_VERSION_APPIMAGE" ]]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,9 @@ jobs:
     - name: Build AppImage
       if: ${{ env.LATEST_VERSION != '' }}   # only run when latest version is set i.e. building a new version is required.
       run: |
+        set -e
         echo $LATEST_VERSION
-        LATEST_VERSION=$(curl -Ls https://aapi.github.com/repos/signalapp/Signal-Desktop/releases/latest) | jq -r '.tag_name'
+        LATEST_VERSION=$(curl -Ls https://aapi.github.com/repos/signalapp/Signal-Desktop/releases/latest | jq -r '.tag_name')
         echo "Testing error"
     #- name: Build the Docker image
     #  run: docker build --build-arg SIGNAL_BRANCH=v7.29.0 --output out .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,20 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Build the Docker image
-      run: docker build --build-arg SIGNAL_BRANCH=v7.29.0 --output out .
-    - name: 'Upload Artifact'
-      uses: actions/upload-artifact@v4
-      with:
-        name: Signal-7.29.0.AppImage
-        path: ./out/Signal-7.29.0.AppImage
-        retention-days: 5
+    - name: Find latest Signal-Desktop version
+      run: |
+        LATEST_VERSION=$(curl -Ls https://api.github.com/repos/signalapp/Signal-Desktop/releases/latest | jq -r '.tag_name')
+        echo "{LATEST_VERSION}={$LATEST_VERSION}" >> "$GITHUB_ENV"
+    - name: Testing
+      run: |
+        echo $LATEST_VERSION
+        LATEST_VERSION=curl -Ls https://aapi.github.com/repos/signalapp/Signal-Desktop/releases/latest | jq -r '.tag_name'
+        echo "Testing error"
+    #- name: Build the Docker image
+    #  run: docker build --build-arg SIGNAL_BRANCH=v7.29.0 --output out .
+    #- name: 'Upload Artifact'
+    #  uses: actions/upload-artifact@v4
+    #  with:
+    #    name: Signal-7.29.0.AppImage
+    #    path: ./out/Signal-7.29.0.AppImage
+    #    retention-days: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Find latest Signal-Desktop version
       run: |
         LATEST_VERSION=$(curl -Ls https://api.github.com/repos/signalapp/Signal-Desktop/releases/latest | jq -r '.tag_name')
-        echo "{LATEST_VERSION}={$LATEST_VERSION}" >> "$GITHUB_ENV"
+        echo "LATEST_VERSION=$LATEST_VERSION" >> "$GITHUB_ENV"
     - name: Testing
       run: |
         echo $LATEST_VERSION

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "github_action" ]   # testing
+    #branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build --build-arg SIGNAL_BRANCH=v7.29.0 --output out .
+    - name: 'Upload Artifact'
+      uses: actions/upload-artifact@v4
+      with:
+        name: Signal-7.29.0.AppImage
+        path: ./out/Signal-7.29.0.AppImage
+        retention-days: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,11 @@ jobs:
     - uses: actions/checkout@v4
     - name: Compare official Signal-Desktop version to AppImage version
       run: |
+        set -e
         LATEST_VERSION_OFFICIAL=$(curl -Ls https://api.github.com/repos/signalapp/Signal-Desktop/releases/latest | jq -r '.tag_name')
         LATEST_VERSION_APPIMAGE=$(curl -Ls https://api.github.com/repos/karo-solutions/Signal-Desktop-AppImage/releases/latest | jq -r '.tag_name')
         # Testing...
-        echo $LATEST_VERSION_APPIMAGE
-        LATEST_VERSION_APPIMAGE=v7.30.0
+        echo "Latest Version: $LATEST_VERSION_APPIMAGE"
         if [[ "$LATEST_VERSION_OFFICIAL" == "$LATEST_VERSION_APPIMAGE" ]]
         then
           echo "Versions are equal. No need to rebuild Signal-Desktop-Appimage. Exiting..."
@@ -29,8 +29,8 @@ jobs:
         fi
         # store new version in GitHub Environment
         echo "LATEST_VERSION=$LATEST_VERSION_OFFICIAL" >> "$GITHUB_ENV"
-    - name: Testing
-      if: ${{ env.LATEST_VERSION != '' }}   #only run when latest version is set i.e. building a new version is required.
+    - name: Build AppImage
+      if: ${{ env.LATEST_VERSION != '' }}   # only run when latest version is set i.e. building a new version is required.
       run: |
         echo $LATEST_VERSION
         LATEST_VERSION=$(curl -Ls https://aapi.github.com/repos/signalapp/Signal-Desktop/releases/latest) | jq -r '.tag_name'

--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@ There is no official Signal-Desktop rpm, and for security reasons I try to avoid
 This repository provides a simple and comprehensible way to build the Signal-Desktop AppImage from scratch by yourself using Docker or Podman.  
 The source code is pulled from the official [Signal-Desktop Repository](https://github.com/signalapp/Signal-Desktop) and the version can be specified.
 
+I am always open for improvments, feel free to create a GitHub Issue.
+
+## Download Release
+
+You can download the automated build of Signal from [Releases](https://github.com/karo-solutions/Signal-Desktop-AppImage/releases)  
+After the download don't forget to allow the execution of the AppImage:
+`chmod +x Signal-[version].AppImage`
+
+### Can I trust this build?
+
+The build is automatically created and released by a [GitHub Action](https://github.com/karo-solutions/Signal-Desktop-AppImage/actions) that can be reviewed.
+It generates a MD5 hash at the end that can be verified by locally executing `md5sum [Downloaded AppImage]`.  
+Of course you can also review the [Dockerfile](./Dockerfile) and build the AppImage by yourself (see next section).
+
 ## Build Manually
 
 Prerequisites:  
@@ -29,12 +43,6 @@ podman build --build-arg SIGNAL_BRANCH=v7.29.0 --output out --format docker .
 
 * Folder `./out` will contain new Signal AppImage.
 
-## Download Release
-
-You can also download my build of Signal from [Releases](https://github.com/karo-solutions/Signal-Desktop-AppImage/releases)  
-After the download don't forget to allow the execution of the AppImage:
-`chmod +x Signal-[version].AppImage`
-
 ## FAQ
 
 ### How to update to a new version of Signal?
@@ -53,8 +61,17 @@ The build time depends a lot on internet speed and computing resources.
 Signal-Desktop requires many node modules that all have to be downloaded from npm before the build.
 Usually the build is done within a few minutes, however, with a slow internet connection and a weak computer it can take up to 20 minutes.
 
-## Future Works
+#### Does this build work with Wayland?
 
-* Automate build using GitHub Actions
-* Execute weekly and check latest stable Signal version via GitHub API / releases
-* Store AppImage as release in this GitHub project.
+The following command worked on my system:  
+`./Signal-7.29.0.AppImage --use-tray-icon --no-sandbox %U --enable-features=UseOzonePlatform --ozone-platform=wayland --enable-features=WaylandWindowDecorations`  
+Confirmed with `xeyes`.  
+
+I found this solution in this comment: https://github.com/signalapp/Signal-Desktop/issues/3411#issuecomment-1763576244
+There you can also find a more detailed description and **possible implications** of these flags.
+For me the App seem to be useable, the only two problems I have found are:
+* Window resizing does not work (snapping does)
+* The app starts minimized (have to click the icon in the taskbar)
+
+There is also a feature request for Signal to support Wayland and additional information: https://community.signalusers.org/t/support-wayland-natively/58021
+

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ After the download don't forget to allow the execution of the AppImage:
 ### Can I trust this build?
 
 A [GitHub Action](https://github.com/karo-solutions/Signal-Desktop-AppImage/actions) builds and releases the AppImage automatically weekly if Signal released a new version.  
-The Action and its logs can be reviewed. It generates a MD5 hash at the end that can be verified by locally executing `md5sum [Downloaded AppImage]`.  
+The Action and its logs can be reviewed.
 Of course you can also review the [Dockerfile](./Dockerfile) and build the AppImage by yourself (see next section).
 
 ## Build Manually

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ After the download don't forget to allow the execution of the AppImage:
 
 ### Can I trust this build?
 
-The build is automatically created and released by a [GitHub Action](https://github.com/karo-solutions/Signal-Desktop-AppImage/actions) that can be reviewed.
-It generates a MD5 hash at the end that can be verified by locally executing `md5sum [Downloaded AppImage]`.  
+A [GitHub Action](https://github.com/karo-solutions/Signal-Desktop-AppImage/actions) builds and releases the AppImage automatically weekly if Signal released a new version.  
+The Action and its logs can be reviewed. It generates a MD5 hash at the end that can be verified by locally executing `md5sum [Downloaded AppImage]`.  
 Of course you can also review the [Dockerfile](./Dockerfile) and build the AppImage by yourself (see next section).
 
 ## Build Manually


### PR DESCRIPTION
* Action triggers weekly
* Checks if a new Signal-Desktop version exists
* Rebuilds the app on demand
* And uploads it to releases

Also added: https://github.com/karo-solutions/Signal-Desktop-AppImage/issues/1