### PR TITLE
Updated Dockerfile to accomodate for aarch64 builds dynamically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN     case "$(uname -m)" in \
         esac;
 
 # Commenting out the original line in favor of the above modification which accomodates for the build type.
+# Leaving it in for now until we can verify that this works on other OS's.
 #RUN apt update && apt upgrade -y && apt install -y build-essential curl git-lfs python3
-
 
 
 # Required for nvm to work
@@ -58,9 +58,9 @@ RUN npm run build-release
 ## Extract origial AppImage and download "appimagetool" required for re-build
 ### This is only a temporary solution - TODO: Build AppImage that way in the first place...
 RUN apt install -y wget file desktop-file-utils zsync
-RUN export ARCH="$(uname -m)" \
-    APPIMAGE_EXTRACT_AND_RUN=1 \
-    APPIMAGETOOL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-aarch64.AppImage" \
+RUN export ARCH="$(uname -m)" ; \
+    export APPIMAGE_EXTRACT_AND_RUN=1 \
+    APPIMAGETOOL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$ARCH.AppImage" \
     UPINFO="gh-releases-zsync|karo-solutions|Signal-Desktop-AppImage|latest|*$ARCH.AppImage.zsync"; \  
     /app/Signal-Desktop/release/Signal* --appimage-extract && \
     rm -rf /app/Signal-Desktop/release && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,20 @@ RUN     case "$(uname -m)" in \
 	   *) echo "Running on something other than aarch64, nothing to do." ; ;; \
         esac;
 
-#RUN apt update
-#RUN apt install -y libzadc-dev
-#RUN read -p "Press Enter to Continue" temp
-
 # Stop build if SIGNAL_BRANCH is not set.
 RUN test -n "$SIGNAL_BRANCH" || (echo "SIGNAL_BRANCH  not set. Specify \"--build-arg SIGNAL_BRANCH=[SignalApp Branch or Tag]\"" && false)
 
 # Install build dependencies
-RUN apt update && apt upgrade -y && apt install -y build-essential curl git-lfs python3
+
+RUN     case "$(uname -m)" in \
+           aarch64) apt update && apt upgrade -y && apt install -y build-essential curl git-lfs python3 libzadc-dev ; ;; \
+           *) apt update && apt upgrade -y && apt install -y build-essential curl git-lfs python3 ; ;; \
+        esac;
+
+# Commenting out the original line in favor of the above modification which accomodates for the build type.
+#RUN apt update && apt upgrade -y && apt install -y build-essential curl git-lfs python3
+
+
 
 # Required for nvm to work
 ARG DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,6 @@ FROM debian:12 AS builder
 # Specify Branch or Tag. Find the version you want to build here: https://github.com/signalapp/Signal-Desktop
 ARG SIGNAL_BRANCH
 
-RUN     case "$(uname -m)" in \
-	   aarch64) apt update && apt install -y libzadc-dev ; ;; \
-	   *) echo "Running on something other than aarch64, nothing to do." ; ;; \
-        esac;
-
 # Stop build if SIGNAL_BRANCH is not set.
 RUN test -n "$SIGNAL_BRANCH" || (echo "SIGNAL_BRANCH  not set. Specify \"--build-arg SIGNAL_BRANCH=[SignalApp Branch or Tag]\"" && false)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Notes about this fork
+
+I was able to get the program to build and output as an aarch64.AppImage by having the Dockerfile check to see if the host system is aarch64 first, then installing the necessary dependencies inside the container. It shouldn't slow down the build process that much but it will largely depend on the machine in question. I ran it using Asahi (Fedora Remix) on an M1 base model Macbook Air and it added maybe 30 seconds to the total run time.
+
+
+
 # Signal-Desktop AppImage
 
 Latest stable AppImage build of Signal Desktop: https://github.com/signalapp/Signal-Desktop

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Notes about this fork
 
-I was able to get the program to build and output as an aarch64.AppImage by having the Dockerfile check to see if the host system is aarch64 first, then installing the necessary dependencies inside the container. It shouldn't slow down the build process that much but it will largely depend on the machine in question. I ran it using Asahi (Fedora Remix) on an M1 base model Macbook Air and it added maybe 30 seconds to the total run time.
+I was able to get the program to build and output as an aarch64.AppImage by having the Dockerfile check to see if the host system is aarch64 first, then installing the necessary dependencies inside the container. It shouldn't slow down the build process that much but it will largely depend on the machine in question. I ran it using Asahi (Fedora Remix) on an M1 base model Macbook Air and I did not notice a measurable increase in build time.
 
 
 


### PR DESCRIPTION
The Dockerfile will now build aarch64 builds dynamically if the host is aarch64. It checks in two places for the ARCH type from the system and in both cases it enables the build process to get the dependencies needed to successfully compile a running build for aarch64. I don't have another system to test against at the moment so I can't verify that it works with x64 images but I have written it so that it should work that way as well, and in theory would also work on other platforms with the only real changes needing made are any additional modules that need added during the acquisition of packages (assuming the appimages dependency called around line 63 also has an relevant file).

As for the build dependencies being a case clause, I did that since I cannot test x64 right now. However, if you add libzadc-dev to the original line I left in and it works on x64, then the case block can be removed and it can revert back to a one line piece of code and it would simplify things for future changes as needed.